### PR TITLE
部分修改以及增加对 NAT 节点端口偏移支持

### DIFF
--- a/app/Controllers/ConfController.php
+++ b/app/Controllers/ConfController.php
@@ -313,22 +313,13 @@ class ConfController extends BaseController
     public static function getClashConfGeneral($General)
     {
         if (count($General) != 0) {
-            foreach ($General as $key => $value) {
-                if (!in_array(
+            foreach ($General as $key) {
+                if (in_array(
                     $key,
                     [
-                        'port',
-                        'socks-port',
-                        'redir-port',
-                        'allow-lan',
-                        'mode',
-                        'log-level',
-                        'external-controller',
-                        'external-ui',
-                        'secret',
-                        'experimental',
-                        'authentication',
-                        'dns'
+                        'Proxy',
+                        'Proxy Group',
+                        'Rule'
                     ]
                 )) {
                     unset($key);

--- a/app/Controllers/ConfController.php
+++ b/app/Controllers/ConfController.php
@@ -327,6 +327,7 @@ class ConfController extends BaseController
                         'external-ui',
                         'secret',
                         'experimental',
+                        'authentication',
                         'dns'
                     ]
                 )) {

--- a/app/Controllers/LinkController.php
+++ b/app/Controllers/LinkController.php
@@ -294,7 +294,7 @@ class LinkController extends BaseController
                     . ', password='
                     . $item['passwd']
                     . URL::getSurgeObfs($item)
-                    . ', tfo=true, udp-relay=true'
+                    . ', udp-relay=true'
                     . PHP_EOL);
             } else {
                 $proxy_group .= ($item['remark']
@@ -308,7 +308,6 @@ class LinkController extends BaseController
                     . $item['passwd']
                     . ', https://raw.githubusercontent.com/lhie1/Rules/master/SSEncrypt.module'
                     . URL::getSurgeObfs($item)
-                    . ', tfo=true'
                     . PHP_EOL);
             }
             $proxy_name .= (', ' . $item['remark']);

--- a/app/Controllers/Mod_Mu/NodeController.php
+++ b/app/Controllers/Mod_Mu/NodeController.php
@@ -52,7 +52,12 @@ class NodeController extends BaseController
             ];
             return $this->echoJson($response, $res);
         }
-        $node_server = explode(';', $node->server);
+        if (in_array($node->sort, [0, 10])) {
+            $node_explode = explode(';', $node->server);
+            $node_server = $node_explode[0];
+        } else {
+            $node_server = $node->server;
+        }
         $res = [
             'ret' => 1,
             'data' => [
@@ -62,7 +67,7 @@ class NodeController extends BaseController
                 'traffic_rate' => $node->traffic_rate,
                 'mu_only' => $node->mu_only,
                 'sort' => $node->sort,
-                'server' => $node_server[0],
+                'server' => $node_server,
                 'type' => 'ss-panel-v3-mod_Uim'
             ],
         ];

--- a/app/Controllers/Mod_Mu/NodeController.php
+++ b/app/Controllers/Mod_Mu/NodeController.php
@@ -52,6 +52,7 @@ class NodeController extends BaseController
             ];
             return $this->echoJson($response, $res);
         }
+        $node_server = explode(';', $node->server);
         $res = [
             'ret' => 1,
             'data' => [
@@ -61,7 +62,7 @@ class NodeController extends BaseController
                 'traffic_rate' => $node->traffic_rate,
                 'mu_only' => $node->mu_only,
                 'sort' => $node->sort,
-                'server' => $node->server,
+                'server' => $node_server[0],
                 'type' => 'ss-panel-v3-mod_Uim'
             ],
         ];
@@ -74,7 +75,8 @@ class NodeController extends BaseController
             static function ($query) {
                 $query->where('sort', '=', 0)
                     ->orWhere('sort', '=', 10)
-                    ->orWhere('sort', '=', 12);
+                    ->orWhere('sort', '=', 12)
+                    ->orWhere('sort', '=', 13);
             }
         )->get();
         $res = [

--- a/app/Controllers/UserController.php
+++ b/app/Controllers/UserController.php
@@ -475,9 +475,6 @@ class UserController extends BaseController
             if ($node->sort == 13) {
                 $server = Tools::ssv2Array($node->server);
                 $array_node['server'] = $server['add'];
-            } elseif (in_array($node->sort, [0, 10])) {
-                $node_server = explode(';', $node->server);
-                $array_node['server'] = $node_server[0];
             } else {
                 $array_node['server'] = $node->server;
             }

--- a/app/Controllers/UserController.php
+++ b/app/Controllers/UserController.php
@@ -474,10 +474,12 @@ class UserController extends BaseController
             $array_node['name']=$node->name;
             if ($node->sort == 13) {
                 $server = Tools::ssv2Array($node->server);
-                $array_node['server']=$server['add'];
-            } else {
+                $array_node['server'] = $server['add'];
+            } elseif (in_array($node->sort, [0, 10])) {
                 $node_server = explode(';', $node->server);
                 $array_node['server'] = $node_server[0];
+            } else {
+                $array_node['server'] = $node->server;
             }
             $array_node['sort']=$node->sort;
             $array_node['info']=$node->info;

--- a/app/Controllers/UserController.php
+++ b/app/Controllers/UserController.php
@@ -476,7 +476,8 @@ class UserController extends BaseController
                 $server = Tools::ssv2Array($node->server);
                 $array_node['server']=$server['add'];
             } else {
-                $array_node['server'] = $node->server;
+                $node_server = explode(';', $node->server);
+                $array_node['server'] = $node_server[0];
             }
             $array_node['sort']=$node->sort;
             $array_node['info']=$node->info;

--- a/app/Utils/Tools.php
+++ b/app/Utils/Tools.php
@@ -536,4 +536,35 @@ class Tools
         }
         return $item;
     }
+
+    public static function OutPort($node, $mu_port)
+    {
+        $node_server = explode(';', $node->server);
+        $node_port = $mu_port;
+        if (strpos($node_server[1], 'port') !== false) {
+            $item = URL::parse_args($node_server[1]);
+            if (strpos($item['port'], '#') !== false) { // 端口偏移，指定端口，格式：8.8.8.8;port=80#1080
+                if (strpos($item['port'], '+') !== false) { // 多个单端口节点，格式：8.8.8.8;port=80#1080+443#8443
+                    $args_explode = explode('+', $item['port']);
+                    foreach ($args_explode as $arg) {
+                        if ((int) substr($arg, 0, strpos($arg, '#')) == $mu_port) {
+                            $node_port = (int) substr($arg, strpos($arg, '#') + 1);
+                        }
+                    }
+                } else {
+                    if ((int) substr($item['port'], 0, strpos($item['port'], '#')) == $mu_port) {
+                        $node_port = (int) substr($item['port'], strpos($item['port'], '#') + 1);
+                    }
+                }
+            } else { // 端口偏移，偏移端口，格式：8.8.8.8;port=1000 or 8.8.8.8;port=-1000
+                $node_port = ($mu_port + (int) $item['port']);
+            }
+        }
+
+        return [
+            'name' => ($node->name . ' - ' . $node_port . ' 单端口'),
+            'address' => $node_server[0],
+            'port' => $node_port
+        ];
+    }
 }

--- a/app/Utils/Tools.php
+++ b/app/Utils/Tools.php
@@ -472,7 +472,7 @@ class Tools
                 $item['tls'] = 'tls';
             }
         }
-        if (count($server) >= 6) {
+        if (count($server) >= 6 && $server[5] != '') {
             $item = array_merge($item, URL::parse_args($server[5]));
             if (array_key_exists('server', $item)) {
                 $item['add'] = $item['server'];
@@ -481,6 +481,9 @@ class Tools
             if (array_key_exists('outside_port', $item)) {
                 $item['port'] = (int)$item['outside_port'];
                 unset($item['outside_port']);
+            }
+            if (isset($item['inside_port'])) {
+                unset($item['inside_port']);
             }
         }
         return $item;

--- a/app/Utils/Tools.php
+++ b/app/Utils/Tools.php
@@ -537,9 +537,9 @@ class Tools
         return $item;
     }
 
-    public static function OutPort($node, $mu_port)
+    public static function OutPort($server, $node_name,$mu_port)
     {
-        $node_server = explode(';', $node->server);
+        $node_server = explode(';', $server);
         $node_port = $mu_port;
         if (strpos($node_server[1], 'port') !== false) {
             $item = URL::parse_args($node_server[1]);
@@ -562,7 +562,7 @@ class Tools
         }
 
         return [
-            'name' => ($node->name . ' - ' . $node_port . ' 单端口'),
+            'name' => ($node_name . ' - ' . $node_port . ' 单端口'),
             'address' => $node_server[0],
             'port' => $node_port
         ];

--- a/app/Utils/URL.php
+++ b/app/Utils/URL.php
@@ -652,6 +652,7 @@ class URL
                     $return_array['port'] = ($return_array['port'] + (int) $item['port']);
                 }
             }
+            $node_name = ($node->name . ' - ' . $return_array['port'] . ' 单端口');
         }
         $return_array['remark'] = $node_name;
         $return_array['class'] = $node->node_class;

--- a/app/Utils/URL.php
+++ b/app/Utils/URL.php
@@ -631,7 +631,7 @@ class URL
         $return_array['passwd'] = $user->passwd;
         $return_array['method'] = $user->method;
         if (strpos($node->server, ';') !== false && $node->sort != 13) {
-            $node_tmp = Tools::OutPort($node, $mu_port);
+            $node_tmp = Tools::OutPort($node->server, $node->name, $mu_port);
             $return_array['address'] = $node_tmp['address'];
             $return_array['port'] = $node_tmp['port'];
             $node_name = $node_tmp['name'];

--- a/app/Utils/URL.php
+++ b/app/Utils/URL.php
@@ -631,28 +631,10 @@ class URL
         $return_array['passwd'] = $user->passwd;
         $return_array['method'] = $user->method;
         if (strpos($node->server, ';') !== false && $node->sort != 13) {
-            $node_server = explode(';', $node->server);
-            $return_array['address'] = $node_server[0];
-            if (strpos($node_server[1], 'port') !== false) {
-                $item = self::parse_args($node_server[1]);
-                if (strpos($item['port'], '#') !== false) { // 端口偏移，指定端口，格式：8.8.8.8;port=80#1080
-                    if (strpos($item['port'], '+') !== false) { // 多个单端口节点，格式：8.8.8.8;port=80#1080+443#8443
-                        $args_explode = explode('+', $item['port']);
-                        foreach ($args_explode as $arg) {
-                            if ((int) substr($arg, 0, strpos($arg, '#')) == $mu_port) {
-                                $return_array['port'] = (int) substr($arg, strpos($arg, '#') + 1);
-                            }
-                        }
-                    } else {
-                        if ((int) substr($item['port'], 0, strpos($item['port'], '#')) == $mu_port) {
-                            $return_array['port'] = (int) substr($item['port'], strpos($item['port'], '#') + 1);
-                        }
-                    }
-                } else { // 端口偏移，偏移端口，格式：8.8.8.8;port=1000 or 8.8.8.8;port=-1000
-                    $return_array['port'] = ($return_array['port'] + (int) $item['port']);
-                }
-            }
-            $node_name = ($node->name . ' - ' . $return_array['port'] . ' 单端口');
+            $node_tmp = Tools::OutPort($node, $mu_port);
+            $return_array['address'] = $node_tmp['address'];
+            $return_array['port'] = $node_tmp['port'];
+            $node_name = $node_tmp['name'];
         }
         $return_array['remark'] = $node_name;
         $return_array['class'] = $node->node_class;

--- a/app/Utils/URL.php
+++ b/app/Utils/URL.php
@@ -233,7 +233,7 @@ class URL
             }
             if ($node->custom_rss == 1 && $node->mu_only != -1 && $is_mu != 0) {
                 foreach ($mu_nodes as $mu_node) {
-                    if ($node->sort == 10) {
+                    if ($node->sort == 10) { // ss 中转
                         $relay_rule_id = 0;
                         $relay_rule = Tools::pick_out_relay_rule($node->id, $mu_node->server, $relay_rules);
                         if (($relay_rule != null) && $relay_rule->dist_node() != null) {
@@ -585,7 +585,7 @@ class URL
         if ($relay_rule != null) {
             $node_name .= ' - ' . $relay_rule->dist_node()->name;
         }
-        if ($mu_port != 0) {
+        if ($mu_port != 0 && $node->sort != 13) {
             $mu_user = User::where('port', '=', $mu_port)->where('is_multi_user', '<>', 0)->first();
             if ($mu_user == null) {
                 return;
@@ -630,6 +630,29 @@ class URL
         }
         $return_array['passwd'] = $user->passwd;
         $return_array['method'] = $user->method;
+        if (strpos($node->server, ';') !== false && $node->sort != 13) {
+            $node_server = explode(';', $node->server);
+            $return_array['address'] = $node_server[0];
+            if (strpos($node_server[1], 'port') !== false) {
+                $item = self::parse_args($node_server[1]);
+                if (strpos($item['port'], '#') !== false) { // 端口偏移，指定端口，格式：8.8.8.8;port=80#1080
+                    if (strpos($item['port'], '+') !== false) { // 多个单端口节点，格式：8.8.8.8;port=80#1080+443#8443
+                        $args_explode = explode('+', $item['port']);
+                        foreach ($args_explode as $arg) {
+                            if ((int) substr($arg, 0, strpos($arg, '#')) == $mu_port) {
+                                $return_array['port'] = (int) substr($arg, strpos($arg, '#') + 1);
+                            }
+                        }
+                    } else {
+                        if ((int) substr($item['port'], 0, strpos($item['port'], '#')) == $mu_port) {
+                            $return_array['port'] = (int) substr($item['port'], strpos($item['port'], '#') + 1);
+                        }
+                    }
+                } else { // 端口偏移，偏移端口，格式：8.8.8.8;port=1000 or 8.8.8.8;port=-1000
+                    $return_array['port'] = ($return_array['port'] + (int) $item['port']);
+                }
+            }
+        }
         $return_array['remark'] = $node_name;
         $return_array['class'] = $node->node_class;
         $return_array['group'] = Config::get('appName');

--- a/resources/conf/clash.tpl
+++ b/resources/conf/clash.tpl
@@ -43,10 +43,8 @@ dns:
     - 1.2.4.8
     - 223.5.5.5
     - 114.114.114.114
-    - tls://dns.rubyfish.cn:853
   fallback:
     - tls://dns.rubyfish.cn:853
-    - tls://dns.google
 
 # Clash DNS 请求逻辑：
 # (1) 当访问一个域名时， nameserver 与 fallback 列表内的所有服务器并发请求，得到域名对应的 IP 地址。

--- a/resources/views/material/doc/index.tpl
+++ b/resources/views/material/doc/index.tpl
@@ -56,5 +56,6 @@
   <script src="//unpkg.com/docsify/lib/plugins/emoji.js"></script>
   <script src="//unpkg.com/docsify/lib/plugins/zoom-image.js"></script>
   <script src="//unpkg.com/docsify-copy-code"></script>
+  <script src="//unpkg.com/prismjs/components/prism-yaml.min.js"></script>
 </body>
 </html>

--- a/resources/views/material/user/node.tpl
+++ b/resources/views/material/user/node.tpl
@@ -1,4 +1,4 @@
-﻿{include file='user/main.tpl'}
+{include file='user/main.tpl'}
 
 <script src="//cdn.jsdelivr.net/gh/SuicidalCat/canvasjs.js@v2.3.1/canvasjs.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/jquery@3.3.1"></script>
@@ -169,7 +169,7 @@
                                                    onClick="urlChange('{$node['id']}',{$single_muport['server']->server},{if $relay_rule != null}{$relay_rule->id}{else}0{/if})">{$node['name']}
                                                     {if $relay_rule != null} - {$relay_rule->dist_node()->name}{/if} -
                                                     单端口 Shadowsocks - 
-                                                    {if strpos($node->server, ';') !== false}{$node_tmp=$tools->OutPort($node, $single_muport)}{$node_tmp['port']}{else}{$single_muport['server']->server}{/if}
+                                                    {if strpos($node->server, ';') !== false}{assign var='node_tmp' value=$tools->OutPort($node['server'], $node['name'], $single_muport['server']->server)}{$node_tmp['port']}{else}{$single_muport['server']->server}{/if}
                                                      端口
                                                 </a>
                                             </div>
@@ -308,7 +308,7 @@
                                                                                    onClick="urlChange('{$node['id']}',{$single_muport['server']->server},{if $relay_rule != null}{$relay_rule->id}{else}0{/if})">{$node['name']}
                                                                                     {if $relay_rule != null} - {$relay_rule->dist_node()->name}{/if}
                                                                                     - 单端口 Shadowsocks -
-                                                                                    {if strpos($node->server, ';') !== false}{$node_tmp=$tools->OutPort($node, $single_muport)}{$node_tmp['port']}{else}{$single_muport['server']->server}{/if}
+                                                                                    {if strpos($node->server, ';') !== false}{assign var='node_tmp' value=$tools->OutPort($node['server'], $node['name'], $single_muport['server']->server)}{$node_tmp['port']}{else}{$single_muport['server']->server}{/if}
                                                                                     端口</a><span
                                                                                         class="label label-brand-accent">←点击节点查看配置信息</span>
                                                                             </p>

--- a/resources/views/material/user/node.tpl
+++ b/resources/views/material/user/node.tpl
@@ -168,7 +168,9 @@
                                                 <a href="javascript:void(0);"
                                                    onClick="urlChange('{$node['id']}',{$single_muport['server']->server},{if $relay_rule != null}{$relay_rule->id}{else}0{/if})">{$node['name']}
                                                     {if $relay_rule != null} - {$relay_rule->dist_node()->name}{/if} -
-                                                    单端口 Shadowsocks - {$single_muport['server']->server} 端口
+                                                    单端口 Shadowsocks - 
+                                                    {if strpos($node->server, ';') !== false}{$node_tmp=$tools->OutPort($node, $single_muport)}{$node_tmp['port']}{else}{$single_muport['server']->server}{/if}
+                                                     端口
                                                 </a>
                                             </div>
                                         {/foreach}
@@ -306,7 +308,7 @@
                                                                                    onClick="urlChange('{$node['id']}',{$single_muport['server']->server},{if $relay_rule != null}{$relay_rule->id}{else}0{/if})">{$node['name']}
                                                                                     {if $relay_rule != null} - {$relay_rule->dist_node()->name}{/if}
                                                                                     - 单端口 Shadowsocks -
-                                                                                    {$single_muport['server']->server}
+                                                                                    {if strpos($node->server, ';') !== false}{$node_tmp=$tools->OutPort($node, $single_muport)}{$node_tmp['port']}{else}{$single_muport['server']->server}{/if}
                                                                                     端口</a><span
                                                                                         class="label label-brand-accent">←点击节点查看配置信息</span>
                                                                             </p>

--- a/resources/views/material/user/node.tpl
+++ b/resources/views/material/user/node.tpl
@@ -169,7 +169,7 @@
                                                    onClick="urlChange('{$node['id']}',{$single_muport['server']->server},{if $relay_rule != null}{$relay_rule->id}{else}0{/if})">{$node['name']}
                                                     {if $relay_rule != null} - {$relay_rule->dist_node()->name}{/if} -
                                                     单端口 Shadowsocks - 
-                                                    {if strpos($node->server, ';') !== false}{assign var='node_tmp' value=$tools->OutPort($node['server'], $node['name'], $single_muport['server']->server)}{$node_tmp['port']}{else}{$single_muport['server']->server}{/if}
+                                                    {if strpos($node['server'], ';') !== false}{assign var='node_tmp' value=$tools->OutPort($node['server'], $node['name'], $single_muport['server']->server)}{$node_tmp['port']}{else}{$single_muport['server']->server}{/if}
                                                      端口
                                                 </a>
                                             </div>
@@ -308,7 +308,7 @@
                                                                                    onClick="urlChange('{$node['id']}',{$single_muport['server']->server},{if $relay_rule != null}{$relay_rule->id}{else}0{/if})">{$node['name']}
                                                                                     {if $relay_rule != null} - {$relay_rule->dist_node()->name}{/if}
                                                                                     - 单端口 Shadowsocks -
-                                                                                    {if strpos($node->server, ';') !== false}{assign var='node_tmp' value=$tools->OutPort($node['server'], $node['name'], $single_muport['server']->server)}{$node_tmp['port']}{else}{$single_muport['server']->server}{/if}
+                                                                                    {if strpos($node['server'], ';') !== false}{assign var='node_tmp' value=$tools->OutPort($node['server'], $node['name'], $single_muport['server']->server)}{$node_tmp['port']}{else}{$single_muport['server']->server}{/if}
                                                                                     端口</a><span
                                                                                         class="label label-brand-accent">←点击节点查看配置信息</span>
                                                                             </p>


### PR DESCRIPTION
**端口偏移需为 ss 或 ss 中转，设为单端口与普通端口并存或只启用单端口。**

---

- 单个端口指定，节点地址格式：`8.8.8.8;port=80#10080`
- 多个端口指定，节点地址格式：`8.8.8.8;port=80#10080+443#10443`

以上指定会在面板和订阅中将原节点端口 80 替换为 10080，443 替换为 10443，更多请使用加号分隔。

---

- 端口偏移，节点地址格式：`8.8.8.8;port=1000` or `8.8.8.8;port=-1000`

以上偏移会在面板和订阅中将使用原节点端口与偏移值相加的所得值。